### PR TITLE
Add logger middleware to faraday connection

### DIFF
--- a/lib/synctera/api_client.rb
+++ b/lib/synctera/api_client.rb
@@ -181,6 +181,7 @@ module Synctera
       Faraday.new(url: config.base_url, ssl: ssl_options, proxy: config.proxy) do |conn|
         basic_auth(conn)
         config.configure_middleware(conn)
+        conn.response :logger, nil, { headers: true, bodies: true, errors: true }
         yield(conn) if block_given?
         conn.adapter(Faraday.default_adapter)
         config.configure_connection(conn)


### PR DESCRIPTION
This adds the response logger middleware so that we can log our requests and responses with the sys level set to info. The debug config doesn't help us because debug is such a high sys level. We could refactor the debug config to conditionally add the logger middleware in addition to this change if we'd like to make this configurable. 